### PR TITLE
Added C++11 CXX flag and changed the output path for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,14 @@ project(projectname)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/lib/cmake-modules")
 
 if(UNIX)
-	set(CMAKE_CXX_FLAGS "-m32 -fvisibility=hidden -std=c++11")
+	set(CMAKE_CXX_FLAGS "-m32 -fvisibility=hidden")
 	set(CMAKE_C_FLAGS "-m32 -fvisibility=hidden")
 	set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS OFF)
 endif()
 
 if(WIN32)
-	SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_SOURCE_DIR}/test/plugins")
-	SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}/test/plugins")
+	SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_SOURCE_DIR}/test/plugins")
+	SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}/test/plugins")
 endif()
 
 # removes the sprintf warnings from plugin-natives

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,14 @@ project(projectname)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/lib/cmake-modules")
 
 if(UNIX)
-	set(CMAKE_CXX_FLAGS "-m32 -fvisibility=hidden")
+	set(CMAKE_CXX_FLAGS "-m32 -fvisibility=hidden -std=c++11")
 	set(CMAKE_C_FLAGS "-m32 -fvisibility=hidden")
 	set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS OFF)
+endif()
+
+if(WIN32)
+	SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_SOURCE_DIR}/test/plugins")
+	SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}/test/plugins")
 endif()
 
 # removes the sprintf warnings from plugin-natives

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ if(UNIX)
 endif()
 
 if(WIN32)
-	SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_SOURCE_DIR}/test/plugins")
-	SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}/test/plugins")
+	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_SOURCE_DIR}/test/plugins")
+	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}/test/plugins")
 endif()
 
 # removes the sprintf warnings from plugin-natives

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,6 @@ The "main" source file with most of the boilerplate code. Includes the
 
 #include "common.hpp"
 #include "natives.hpp"
-#include "plugin-natives/NativesMain.hpp" // must be included last
 
 logprintf_t logprintf;
 

--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -8,7 +8,6 @@ The code here acts as the translation between AMX data types and native types.
 */
 
 #include "natives.hpp"
-#include "plugin-natives/NativeFunc.hpp"
 
 cell Natives::Function(AMX* amx, cell* params)
 {

--- a/src/natives.hpp
+++ b/src/natives.hpp
@@ -12,7 +12,6 @@ Contains all the `PAWN_NATIVE_DECL` for native function declarations.
 #include <amx/amx2.h>
 
 #include "common.hpp"
-#include "plugin-natives/NativeFunc.hpp" // must be included last
 
 namespace Natives {
 cell Function(AMX* amx, cell* params);


### PR DESCRIPTION
Added Flags

Also changed the output path for Windows, since (CMake) adds the `Release` and `Debug` folder into the plugins folder which ends up with sampctl not being able to find it.

Removed includes for removed libraries (natives-plugin)