### PR TITLE
Update README with build info for VS 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ And that will generate a Visual Studio project inside `build/` ready for you to 
 Alternatively, you can simply open Visual Studio and click `File > Open > CMake...` and just open the `CMakeLists.txt`
 file directly for a slightly different development experience.
 
-#### Visual Studio 2019 users on an x64 Windows Host
+#### Visual Studio 2019 users on an x86_64 Windows Host
 You have to manually force CMake to generate files for x86 architecture; can only do this from Command-line so far.
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -103,10 +103,21 @@ cd build
 cmake ..
 ```
 
-And that will generate a Visual Studio project inside `build/` ready for you to open in Visual Studio.
+
+And that will generate a Visual Studio project inside `build/` ready for you to open in Visual Studio*.
 
 Alternatively, you can simply open Visual Studio and click `File > Open > CMake...` and just open the `CMakeLists.txt`
 file directly for a slightly different development experience.
+
+#### Visual Studio 2019 users on an x64 Windows Host
+You have to manually force CMake to generate files for x86 architecture; can only do this from Command-line so far.
+
+```powershell
+mkdir build
+cd build
+cmake -G "Visual Studio 16 2019" -A Win32 ..
+```
+
 
 ## Explanation of Every Important File
 


### PR DESCRIPTION
Add build info for VS 2019 users on an x64 host.

Could only find a way to get it to work via command-line; if anyone else running VS 2019 finds a way to do it from the `File > Open > Cmake...` menu inside Visual Studio that should be updated as well.